### PR TITLE
Fix portfolio copy and image accessibility

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -17,7 +17,7 @@ export default function AboutPage() {
         <section className="mt-16 space-y-8">
           <TextBlock title="Why engineering">
             <p>
-              I worked retail for most of my early working life and eventually found it unfulfilling. I enjoyed my coworkers, but the work became repetitive, and I wanted a path that pushed me intellectually and consciously.
+              I worked retail for most of my early working life and eventually found it unfulfilling. I enjoyed my coworkers, but the work became repetitive, and I wanted a path that pushed me intellectually and professionally.
             </p>
             <p>
               A few years in engineering school changed how I saw the physical world. One of the biggest leaps for me was learning the Fourier Transform and seeing how powerful mathematical tools could explain real signals and systems.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({ children }: Readonly<{ children: ReactNode 
   return (
     <html lang="en" className={`${inter.variable} ${spaceGrotesk.variable}`}>
       <body className="font-sans antialiased">
-        <div className="min-h-screen overflow-hidden">
+        <div className="min-h-screen">
           <SiteHeader />
           {children}
         </div>

--- a/app/projects/bluetooth-audio/page.tsx
+++ b/app/projects/bluetooth-audio/page.tsx
@@ -27,7 +27,7 @@ export default function BluetoothAudioPage() {
 
         <TextBlock title="Results">
           <p>
-            The enhancement led to years of wireless audio use. If I rebuilt it now, I would likely design a dedicated circuit board and use an isolated DC supply instead of a dedicated battery system.
+            The upgrade gave me years of reliable wireless audio. If I rebuilt it now, I would likely design a dedicated circuit board and use an isolated DC supply instead of a dedicated battery system.
           </p>
         </TextBlock>
 

--- a/app/projects/slam-drone/page.tsx
+++ b/app/projects/slam-drone/page.tsx
@@ -12,7 +12,7 @@ export default function SlamDronePage() {
       <section className="mt-16 space-y-8">
         <TextBlock title="Introduction">
           <p>
-            As our senior design project, our group chose to work with a SLAM algorithm and put it onto a drone. Deep learning was part of the intended navigation approach, giving the system a way to make better decisions based on training data.
+            As our senior design project, our group chose to work with a SLAM algorithm and run it on a drone. Deep learning was part of the intended navigation approach, giving the system a way to make better decisions based on training data.
           </p>
           <p>
             The project was the culmination of our undergraduate engineering education and was presented for Fresno State Projects Day in May 2018.
@@ -21,7 +21,7 @@ export default function SlamDronePage() {
 
         <TextBlock title="Synopsis">
           <p>
-            Our group liked drones, computers, and automation, so we wanted a project that combined those interests into a meaningful challenge. After attending a drone conference in Las Vegas, we set our minds on creating something that integrated navigation, mapping, and machine learning.
+            Our group liked drones, computers, and automation, so we wanted a project that combined those interests into a meaningful challenge. After attending a drone conference in Las Vegas, we set our sights on creating something that integrated navigation, mapping, and machine learning.
           </p>
           <p>
             The concept coupled Jetson&apos;s computing capabilities with Intel RealSense sensing to create an autonomous system that could operate in a given environment while mapping its location. We planned to start with 2D navigation using a ground-based rover before expanding into a flying drone.

--- a/app/projects/web-development/page.tsx
+++ b/app/projects/web-development/page.tsx
@@ -30,7 +30,7 @@ export default function WebDevelopmentPage() {
 
         <div className="grid gap-6 md:grid-cols-2">
           <ImageNote src="/images/web3.jpg" caption="A website for my dad's trucking company." />
-          <ImageNote src="/images/web2.jpg" caption="A PHP endpoint used to feed a site current weather information." />
+          <ImageNote src="/images/web2.jpg" caption="A PHP endpoint used to feed current weather information to a site." />
         </div>
       </section>
     </ProjectShell>

--- a/components/ExpandableImage.tsx
+++ b/components/ExpandableImage.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useId, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 
 type ExpandableImageProps = {
   src: string
@@ -11,12 +11,18 @@ type ExpandableImageProps = {
 
 export function ExpandableImage({ src, alt = '', caption, className = '' }: ExpandableImageProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
   const titleId = useId()
+  const accessibleName = alt || caption || 'image'
 
   useEffect(() => {
     if (!isOpen) {
       return
     }
+
+    const previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null
+
+    closeButtonRef.current?.focus()
 
     function closeOnEscape(event: KeyboardEvent) {
       if (event.key === 'Escape') {
@@ -25,25 +31,28 @@ export function ExpandableImage({ src, alt = '', caption, className = '' }: Expa
     }
 
     document.addEventListener('keydown', closeOnEscape)
-    return () => document.removeEventListener('keydown', closeOnEscape)
+    return () => {
+      document.removeEventListener('keydown', closeOnEscape)
+      previousFocus?.focus()
+    }
   }, [isOpen])
 
   return (
     <>
-      <button className="group relative block w-full cursor-zoom-in overflow-hidden text-left" type="button" onClick={() => setIsOpen(true)} aria-label="Expand image">
-        <img className={className} src={src} alt={alt} />
+      <button className="group relative block w-full cursor-zoom-in overflow-hidden text-left" type="button" onClick={() => setIsOpen(true)} aria-label={`Expand ${accessibleName}`}>
+        <img className={className} src={src} alt={accessibleName} />
         <span className="pointer-events-none absolute bottom-4 right-4 rounded-full border border-white/15 bg-ink/75 px-3 py-1 text-xs font-semibold text-white opacity-0 backdrop-blur transition group-hover:opacity-100 group-focus-visible:opacity-100">
           Expand
         </span>
       </button>
 
       {isOpen ? (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-ink/90 p-4 backdrop-blur-md" role="dialog" aria-modal="true" aria-labelledby={caption ? titleId : undefined} onClick={() => setIsOpen(false)}>
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-ink/90 p-4 backdrop-blur-md" role="dialog" aria-modal="true" aria-label={caption ? undefined : accessibleName} aria-labelledby={caption ? titleId : undefined} onClick={() => setIsOpen(false)}>
           <div className="relative max-h-full max-w-6xl" onClick={(event) => event.stopPropagation()}>
-            <button className="absolute right-3 top-3 z-10 rounded-full border border-white/15 bg-ink/80 px-4 py-2 text-sm font-semibold text-white backdrop-blur transition hover:bg-white/10" type="button" onClick={() => setIsOpen(false)}>
+            <button ref={closeButtonRef} className="absolute right-3 top-3 z-10 rounded-full border border-white/15 bg-ink/80 px-4 py-2 text-sm font-semibold text-white backdrop-blur transition hover:bg-white/10" type="button" onClick={() => setIsOpen(false)}>
               Close
             </button>
-            <img className="max-h-[82vh] w-auto max-w-full rounded-2xl border border-white/10 object-contain shadow-glow" src={src} alt={alt} />
+            <img className="max-h-[82vh] w-auto max-w-full rounded-2xl border border-white/10 object-contain shadow-glow" src={src} alt={accessibleName} />
             {caption ? (
               <p id={titleId} className="mx-auto mt-4 max-w-3xl text-center text-sm leading-6 text-slate-300">
                 {caption}

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -6,7 +6,7 @@ export function ProjectCard({ project }: { project: Project }) {
   const card = (
     <Card as="article" className="group h-full" interactive>
       <div className="aspect-[16/10] overflow-hidden bg-slate-900">
-        <img className="h-full w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 group-hover:opacity-100" src={project.image} alt="" />
+        <img className="h-full w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 group-hover:opacity-100" src={project.image} alt={project.title} />
       </div>
       <div className="flex flex-col p-6">
         <div className="mb-4 flex flex-wrap gap-2">

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -17,7 +17,7 @@ export function SiteHeader() {
             <Link className="transition hover:text-white" href="/about">
               About
             </Link>
-            <a className="text-slate-400 transition hover:text-white" href="https://github.com/castab/showcase" aria-label="GitHub source">
+            <a className="text-slate-400 transition hover:text-white" href="https://github.com/castab/personal-portfolio" aria-label="GitHub source">
               <GitHubIcon className="h-5 w-5" />
             </a>
           </div>


### PR DESCRIPTION
## Summary
- update stale GitHub source link to the renamed personal-portfolio repository
- revise awkward project/about copy
- improve image alt text, expandable image labels, and modal focus handling
- remove root overflow that could interfere with sticky header behavior

## Testing
- npm run lint
- npm run build